### PR TITLE
Get episode information

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -7,4 +7,8 @@ let imdbCrawler = new CrawlerImdb(imdbCode)
 imdbCrawler.getBasic(function (data) {
   console.log('Serie:')
   console.log(data)
+
+  imdbCrawler.getEpisodes(imdbCode, function (data) {
+    console.log(data)
+  })
 })

--- a/lib/node-imdb-crawler.js
+++ b/lib/node-imdb-crawler.js
@@ -36,6 +36,81 @@ class CrawlerImdb {
       callback(this.title)
     })
   }
+
+  getEpisodes (id, callback) {
+    let Crawler = require('crawler')
+    let seasonURLs = []
+    let epList = []
+
+    const finish = () => {
+      this.title.setEpisodes(epList)
+      callback(this.title.episodes)
+    }
+
+    const mainPageCrawler = new Crawler({
+      maxConnections: 10,
+      // This will be called for each crawled page
+      callback: (error, res, done) => {
+        if (error) {
+          console.log(error)
+        } else {
+          var $ = res.$
+          seasonURLs = $("div.seasons-and-year-nav div>a[href*='?season=']")
+            .toArray()
+            .map(el => $(el).attr('href'))
+
+          if (seasonURLs.length === 0) {
+            finish()
+          } else {
+            seasonURLs.forEach(url => {
+              seasonCrawler.queue('http://www.imdb.com/' + url)
+            })
+          }
+        }
+        done()
+      }
+    })
+
+    mainPageCrawler.queue('http://www.imdb.com/title/' + id)
+
+    const seasonCrawler = new Crawler({
+      maxConnections: 10,
+      callback: (error, res, done) => {
+        if (error) {
+          console.log(error)
+        } else {
+          var $ = res.$
+
+          epList = [...epList, ...$('div.list.detail.eplist > .list_item').toArray().map((el, index) => ({
+            name: $(el).find('strong a').text(),
+            season: parseInt(res.request.uri.query.slice(-1)),
+            epNum: index + 1,
+            airDate: $(el).find('div.airdate').text().trim(),
+            summary: $(el).find('div.item_description').text().trim(),
+            image: $(el).find('div.image img').attr('src')
+          }))]
+
+          epList = epList.sort((a, b) => {
+            if (a.season < b.season) {
+              return -1
+            } else if (a.season > b.season) {
+              return 1
+            } else if (a.epNum < b.epNum) {
+              return -1
+            } else if (a.epNum > b.epNum) {
+              return 1
+            } else {
+              return 0
+            }
+          })
+        }
+        done()
+      }
+    })
+
+    // when all requests are completed
+    seasonCrawler.on('drain', finish)
+  }
 }
 
 module.exports = CrawlerImdb

--- a/lib/title.js
+++ b/lib/title.js
@@ -20,6 +20,10 @@ class Title {
     var _genre = genre.trim()
     this.genres.push(_genre)
   }
+
+  setEpisodes (eps) {
+    this.episodes = eps
+  }
 }
 
 module.exports = Title

--- a/test/test.js
+++ b/test/test.js
@@ -3,8 +3,10 @@
 const expect = require('chai').expect
 const CrawlerImdb = require('../index')
 const imdbCode = 'tt0944947'
+const imdbCodeMovie = 'tt6788942'
 
 let imdbCrawler = new CrawlerImdb(imdbCode)
+let imdbCrawlerNoEps = new CrawlerImdb(imdbCodeMovie)
 
 describe('#getBasic', function () {
   this.timeout(10000)
@@ -32,5 +34,48 @@ describe('#getBasic', function () {
 
   it('should get genres', function () {
     expect(title.genres).to.eql(['Adventure', 'Drama', 'Fantasy', 'Romance'])
+  })
+})
+
+describe('#getEpisodes', function () {
+  this.timeout(10000)
+
+  let episodes = null
+  before(function (done) {
+    imdbCrawler.getEpisodes(imdbCode, function (data) {
+      episodes = data
+      done()
+    })
+  })
+
+  it('should get episode list', function () {
+    expect(episodes).to.be.an.instanceof(Array)
+  })
+
+  it('should get info for single episode', function () {
+    expect(episodes[0].name).to.have.string('Winter Is Coming')
+    expect(episodes[0].season).to.equal(1)
+    expect(episodes[0].epNum).to.equal(1)
+    expect(episodes[0].airDate).to.have.string('17 Apr. 2011')
+    expect(episodes[0].summary).to.have.string('Jon Arryn, the Hand of the King, is dead. King Robert Baratheon plans to ask his oldest friend, Eddard Stark, to take Jon\'s place. Across the sea, Viserys Targaryen plans to wed his sister to a nomadic warlord in exchange for an army.')
+    expect(episodes[0].image).to.have.string('http')
+    expect(episodes[0].image).to.match(/.(jpg|jpeg|png|gif)$/i)
+  })
+})
+
+describe('#getEpisodesForMovie', function () {
+  this.timeout(10000)
+
+  let episodes = null
+  before(function (done) {
+    imdbCrawlerNoEps.getEpisodes(imdbCodeMovie, function (data) {
+      episodes = data
+      done()
+    })
+  })
+
+  it('should return nothing if title has no episodes', function () {
+    expect(episodes).to.be.an.instanceof(Array)
+    expect(episodes).to.have.length(0)
   })
 })


### PR DESCRIPTION
Adds the ability to get episode information. Returns an array of episodes sorted by array length. Returns nothing if returning a movie (i.e. no episodes).

Tested that first episode of GoT has proper values and that an array is returned. Tests that a movie episode list returns an empty array. Did not test sorting (need `chai-sort` plugin).

Let me know if there are any adjustments to be made!

Closes #3.